### PR TITLE
Fix for StateReference::tryFindLocalHandler()

### DIFF
--- a/src/main/java/com/github/oxo42/stateless4j/StateRepresentation.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateRepresentation.java
@@ -4,8 +4,12 @@ import com.github.oxo42.stateless4j.delegates.Action1;
 import com.github.oxo42.stateless4j.delegates.Action2;
 import com.github.oxo42.stateless4j.transitions.Transition;
 import com.github.oxo42.stateless4j.triggers.TriggerBehaviour;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class StateRepresentation<S, T> {
 
@@ -54,7 +58,7 @@ public class StateRepresentation<S, T> {
             throw new IllegalStateException("Multiple permitted exit transitions are configured from state '" + trigger + "' for trigger '" + state + "'. Guard clauses must be mutually exclusive.");
         }
 
-        return actual.get(0);
+        return actual.isEmpty() ? null : actual.get(0);
     }
 
     public void addEntryAction(final T trigger, final Action2<Transition<S, T>, Object[]> action) {

--- a/src/test/java/com/github/oxo42/stateless4j/StateRepresentationTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/StateRepresentationTests.java
@@ -4,40 +4,13 @@ import com.github.oxo42.stateless4j.delegates.Action1;
 import com.github.oxo42.stateless4j.delegates.Action2;
 import com.github.oxo42.stateless4j.transitions.Transition;
 import com.github.oxo42.stateless4j.triggers.IgnoredTriggerBehaviour;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class StateRepresentationTests {
 
@@ -340,6 +313,13 @@ public class StateRepresentationTests {
     @Test
     public void WhenTransitionExists_TriggerCanBeFired() {
         StateRepresentation<State, Trigger> rep = CreateRepresentation(State.B);
+        assertFalse(rep.canHandle(Trigger.X));
+    }
+
+    @Test
+    public void WhenTransitionExistsButGuardConditionNotMet_TriggerCanBeFired() {
+        StateRepresentation<State, Trigger> rep = CreateRepresentation(State.B);
+        rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(Trigger.X, IgnoredTriggerBehaviourTests.returnFalse));
         assertFalse(rep.canHandle(Trigger.X));
     }
 


### PR DESCRIPTION
tryFindLocalHandler now returns null if all possible TriggerBehaviours have unmet guard conditions.
