### PR TITLE
Add License

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,7 @@ methods being called repeatedly because the `OnHold` state is a substate of the 
 
 Entry/Exit event handlers can be supplied with a parameter of type `Transition` that describes the trigger,
 source and destination states.
+
+## License ##
+
+Apache 2.0 License


### PR DESCRIPTION
On the old website (https://code.google.com/p/stateless4j/) it mentions that this project is Apache 2 licensed, but I'm not seeing it anywhere in the git repo.
