### PR TITLE
support external state change that can fail

### DIFF
--- a/src/main/java/com/github/oxo42/stateless4j/delegates/BooleanAction.java
+++ b/src/main/java/com/github/oxo42/stateless4j/delegates/BooleanAction.java
@@ -1,0 +1,16 @@
+package com.github.oxo42.stateless4j.delegates;
+
+/**
+ * Represents an operation that accepts an input and returns success or fail
+ *
+ * @param <T> The type of the input to the operation
+ */
+public interface BooleanAction<T> {
+
+    /**
+     * Performs this operation on the given input
+     *
+     * @param arg1 Input argument
+     */
+    boolean doIt(T arg1);
+}


### PR DESCRIPTION
I changed the state mutator to be able to return a boolean - so the set state can fail
this can be used when trying to set the state in DB using optimistic locking, which can fail to set the state.
