### PR TITLE
Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <!--<source>1.8</source>
-                    <target>1.8</target>-->
                     <release>11</release>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <!--<source>1.8</source>
+                    <target>1.8</target>-->
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -165,7 +166,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <source>8</source>
+                    <source>11</source>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Hi Team,
I have changed the version of Java from 8 to 11. It is always better to use the latest version of Java. It provides latest features and more modern way to code. We have been using this library code in our project since long and now planning to migrate our base code to Java11. This is when I tried to migrate Stateless4j also into Java11.
Please take a look and approve and merge if all looks good.