### PR TITLE
Remove travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: java
-jdk:
-  - openjdk11

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Maven
     </dependency>
 ```
 
-[![Build Status](https://api.travis-ci.org/stateless4j/stateless4j.svg?branch=master)](https://travis-ci.org/stateless4j/stateless4j)
-
 Introduction
 ============
 Create **state machines** and lightweight state machine-based workflows **directly in java code**.


### PR DESCRIPTION
Travis org ceased to provide free service, so we must search
for alternative. Remove travis config.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>