### PR TITLE
Guard from NPE on this.state

### DIFF
--- a/src/main/java/com/github/oxo42/stateless4j/StateRepresentation.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateRepresentation.java
@@ -163,11 +163,11 @@ public class StateRepresentation<S, T> {
                 return true;
             }
         }
-        return this.state.equals(stateToCheck);
+        return this.state != null && this.state.equals(stateToCheck);
     }
 
     public boolean isIncludedIn(S stateToCheck) {
-        return this.state.equals(stateToCheck) || (superstate != null && superstate.isIncludedIn(stateToCheck));
+        return this.state != null && this.state.equals(stateToCheck) || (superstate != null && superstate.isIncludedIn(stateToCheck));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
We have several NPE due to this:

Type
java.lang.NullPointerException
java.lang.NullPointerException: 
  at com.github.oxo42.stateless4j.StateRepresentation.includes (StateRepresentation.java:167)
  at com.github.oxo42.stateless4j.StateRepresentation.enter (StateRepresentation.java:97)
  at com.github.oxo42.stateless4j.StateMachine.publicFire (StateMachine.java:199)
  at com.github.oxo42.stateless4j.StateMachine.fire (StateMachine.java:125)
  at com.raumfeld.android.controller.clean.core.statemachine.HostStateMachine.fire (HostStateMachine.kt:81)
  at com.raumfeld.android.controller.clean.core.statemachine.HostStateMachine.access$fire (HostStateMachine.kt:22)
  at com.raumfeld.android.controller.clean.core.statemachine.HostStateMachine$onEvent$1.run (HostStateMachine.kt:69)
  at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:462)
  at java.util.concurrent.FutureTask.run (FutureTask.java:266)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:920)